### PR TITLE
remove mavimo/phpstan-junit formatter (included in phpstan)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "http-interop/http-factory-guzzle": "^1.0",
         "infection/infection": "^0.15.3|^0.16.3",
         "laminas/laminas-diactoros": "^2.0",
-        "mavimo/phpstan-junit": "^0.3",
         "nyholm/psr7": "^1.0",
         "php-coveralls/php-coveralls": "^2.2",
         "phploc/phploc": "^5.0|^6.0.2",


### PR DESCRIPTION
Remove the package `mavimo/phpstan-junit` since the junit reporting format is included in PHPStan starting from [0.12.4](https://github.com/phpstan/phpstan/releases/tag/0.12.4) so no need to extra package 🎉 

Let me know if there is something that you think should be changed here ;)

PS: I really appreciate if you can mark projects in this orgs as `hacktoberfest` "allowed" (mean you need to add a tag to each project with label `hacktoberfest` as reported here https://hacktoberfest.digitalocean.com/hacktoberfest-update )